### PR TITLE
Don't backup replays by default

### DIFF
--- a/JustBackup/JustBackup.cs
+++ b/JustBackup/JustBackup.cs
@@ -248,6 +248,7 @@ namespace JustBackup
             {
                 string dirName = Path.GetFileName(directory);
                 //if (dirName.Equals("splatoon", StringComparison.OrdinalIgnoreCase)) continue; //don't need to backup backups
+                if (dirName.Equals("replay", StringComparison.OrdinalIgnoreCase) && !all) continue; //don't backup replays by default
                 var path = Path.Combine(dest, dirName);
                 if (!Directory.Exists(path))
                 {


### PR DESCRIPTION
Using plogon such as https://github.com/UnknownX7/ARealmRecorded.git will create multiple replays under game's default config folder. Backup them by default bloat up the archive size significantly and increase the processing time as well. Personally I think we should only backup replays when user enable the "backup all" option. 