### PR TITLE
use dynamic path for dalamud configs fix#23

### DIFF
--- a/JustBackup/JustBackup.cs
+++ b/JustBackup/JustBackup.cs
@@ -16,6 +16,7 @@ using ECommons.Schedulers;
 using ECommons;
 using ECommons.Funding;
 using Dalamud.Interface.ImGuiNotification;
+using Dalamud.Common;
 
 namespace JustBackup
 {
@@ -211,12 +212,12 @@ namespace JustBackup
                     }
                     try
                     {
-                        var appDataDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-                        var xivlauncherDir = Path.Combine(appDataDir, "XIVLauncher");
-                        var ConfigurationPath = Path.Combine(xivlauncherDir, "dalamudConfig.json");
+                        var dalamudRoot = Svc.PluginInterface.GetType().Assembly.GetType("Dalamud.Service`1", true)!.MakeGenericType(Svc.PluginInterface.GetType().Assembly.GetType("Dalamud.Dalamud", true)!).GetMethod("Get")!.Invoke(null, BindingFlags.Default, null, [], null);
+                        var dalamudStartInfo = dalamudRoot?.GetType().GetProperty("StartInfo", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(dalamudRoot) as DalamudStartInfo;
+                        var ConfigurationPath = dalamudStartInfo.ConfigurationPath;
                         PluginLog.Verbose($"Copying from {ConfigurationPath} to {temp}");
                         CopyFile(ConfigurationPath, temp);
-                        var UIConfigurationPath = Path.Combine(xivlauncherDir, "dalamudUI.ini");
+                        var UIConfigurationPath = Path.Combine(Path.GetDirectoryName(ConfigurationPath), "dalamudUI.ini");
                         PluginLog.Verbose($"Copying from {UIConfigurationPath} to {temp}");
                         CopyFile(UIConfigurationPath, temp);
                     }

--- a/JustBackup/JustBackup.csproj
+++ b/JustBackup/JustBackup.csproj
@@ -38,6 +38,10 @@
 			<HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="Dalamud.Common">
+			<HintPath>$(DalamudLibPath)Dalamud.Common.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 		<Reference Include="ImGui.NET">
 			<HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
 			<Private>False</Private>


### PR DESCRIPTION
use reflection to get StartInfo in order to an accurate path

it can solve the problem that Dalamud is not in AppData

e.g. CN clinet. in fact, Dalamud does allow modification of this path, although the vast majority of people would not do so

Thanks @NiGuangOwO provide code to me